### PR TITLE
set encoding to utf8 for CJK langguage files support in Windows.

### DIFF
--- a/representty.py
+++ b/representty.py
@@ -20,7 +20,7 @@ class ShowTheSlide:
 
 class Presentation:
     def __init__(self, filename):
-        with open(filename) as file:
+        with open(filename, encoding="utf8") as file:
             self.slides = re.split(r"====+", file.read())
         self.index = {}
         for i, slide in enumerate(self.slides):


### PR DESCRIPTION
The default encoding in Traditional Chinese version Windows is Big5, opening unicode encoded files for Traditional Chinese language in Windows would raise the decoding exception.I add the encoding argument to unicode to prevent for such errors.